### PR TITLE
Fix hardcoded resource name

### DIFF
--- a/html/js/modules/fetch.js
+++ b/html/js/modules/fetch.js
@@ -10,7 +10,7 @@ export const fetchNUI = async (cbname, data) => {
         },
         body: JSON.stringify(data)
     };
-    const resp = await fetch(`https://anims/${cbname}`, options);
+    const resp = await fetch(`https://${GetParentResourceName()}/${cbname}`, options);
     return await resp.json();
 };
 

--- a/html/js/modules/fetch.js
+++ b/html/js/modules/fetch.js
@@ -1,6 +1,7 @@
 // All favorites will be sotred in favoriteAnims
 
 const doc = document;
+const resourceName = window.GetParentResourceName ? GetParentResourceName () : 'anims';
 
 export const fetchNUI = async (cbname, data) => {
     const options = {
@@ -10,7 +11,7 @@ export const fetchNUI = async (cbname, data) => {
         },
         body: JSON.stringify(data)
     };
-    const resp = await fetch(`https://${GetParentResourceName()}/${cbname}`, options);
+    const resp = await fetch(`https://${resourceName}/${cbname}`, options);
     return await resp.json();
 };
 

--- a/server/update.lua
+++ b/server/update.lua
@@ -1,5 +1,5 @@
 local firstTime = false
-local versionData = json.decode(LoadResourceFile('anims', 'update.json'))
+local versionData = json.decode(LoadResourceFile(GetCurrentResourceName(), 'update.json'))
 
 local function checkVersion(e, latest, _)
     local latest = json.decode(latest)

--- a/server/update.lua
+++ b/server/update.lua
@@ -1,5 +1,6 @@
 local firstTime = false
-local versionData = json.decode(LoadResourceFile(GetCurrentResourceName(), 'update.json'))
+local resourceName = GetCurrentResourceName() or 'anims'
+local versionData = json.decode(LoadResourceFile(resourceName, 'update.json'))
 
 local function checkVersion(e, latest, _)
     local latest = json.decode(latest)


### PR DESCRIPTION
https://github.com/BombayV/anims/issues/41

This issue would not have existed if resource name wasn't hardcoded. To prevent this we use `GetParentResourceName()` in NUI and `GetCurrentResourceName()` in server/update.lua.